### PR TITLE
Fix bug with sprint position XP calculations

### DIFF
--- a/structures/sprint.py
+++ b/structures/sprint.py
@@ -464,7 +464,7 @@ class Sprint:
             is_sprint_winner = result['wordcount'] == highest_word_count
             if position <= 5 and len(results) > 1:
 
-                extra_xp = math.ceil(Experience.XP_WIN_SPRINT / self.WINNING_POSITION if is_sprint_winner else position)
+                extra_xp = math.ceil(Experience.XP_WIN_SPRINT / (self.WINNING_POSITION if is_sprint_winner else position))
                 result['xp'] += extra_xp
                 await result['user'].add_xp(extra_xp)
 


### PR DESCRIPTION
Closes #84 

Testing done:

1) tested w/ two people sprinting; confirmed that the sprinter w/ the higher word count got 125 xp and the second place sprinter got 75 xp

2) tested w/ two people sprinting; confirmed that if they had the same WC, they both got 125 xp