### PR TITLE
Update goal calculation logic to prevent division by zero if end of g…

### DIFF
--- a/cogs/writing/goal.py
+++ b/cogs/writing/goal.py
@@ -153,7 +153,7 @@ class Goal(commands.Cog, CommandWrapper):
                     hours = left['hours']
                     days = days + (1 if hours > 0 else 0)
                     if words_remaining > 0:
-                        average_wordcount_needed = math.ceil(words_remaining / days)
+                        average_wordcount_needed = math.ceil(words_remaining / (1 if days == 0 else days))
                         text += "\n" + lib.get_string('goal:rate', user.get_guild()).format(average_wordcount_needed, type_string)
                 if words_remaining == 0:
                     # They met their goal!


### PR DESCRIPTION
…oal is near

## Description
as goals come to an end, the days/hours/minutes remaining in the time left to complete them draws closer and closer to zero. This means that when calculating the words/day necessary to meet a goal (or see if it is already met), we are hitting a division by zero error. This only affects non-daily goals.

## Testing
I artificially set days remaining = 0 and reproduced the bug w/ a weekly goal; after my change, the goal was displayed as expected.