### PR TITLE
Remove a not-so-reassuring message from reassurances list

### DIFF
--- a/assets/json/en/reassure.json
+++ b/assets/json/en/reassure.json
@@ -29,7 +29,6 @@
     "You always know how to find that silver lining.",
     "You're someone's reason to smile.",
     "I appreciate you.",
-    "If I wasn't a bot, I'd be all over you right now",
     "You're one of a kind.",
     "At your absolute best, you still won't be good enough for the wrong person. At your worst, you'll still be worth it to the right person.",
     "Don't allow someone to make you feel you're not good enough",


### PR DESCRIPTION
From a request in the discord server. I also looked through the rest of the reassurances in the file, but they all seem to be solidly reassuring