### PR TITLE
Add sprint purge to documentation

### DIFF
--- a/cogs/util/help.py
+++ b/cogs/util/help.py
@@ -232,6 +232,7 @@ class Help(commands.Cog, CommandWrapper):
             sprint_embed.add_field(name='`sprint notify`', value=lib.get_string('help:sprintNotifySub', user.get_guild()), inline=True)
             sprint_embed.add_field(name='`sprint forget`', value=lib.get_string('help:sprintForgetSub', user.get_guild()), inline=True)
             sprint_embed.add_field(name='`sprint status`', value=lib.get_string('help:sprintStatusSub', user.get_guild()), inline=True)
+            sprint_embed.add_field(name='`sprint purge`', value=lib.get_string('help:sprintPurgeSub', user.get_guild()), inline=True)
             sprint_embed.set_footer(text=lib.get_string('help:sprintFooter', user.get_guild()))
 
             return await context.send(embed=sprint_embed)

--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -285,6 +285,7 @@
     "help:sprintNotifySub": "You will now get notification when someone stats a new sprint on your current server.",
     "help:sprintForgetSub": "You will now no longer be notified when someone starts a new sprint on your current server.",
     "help:sprintStatusSub": "Shows your current word count for the current sprint.",
+    "help:sprintPurgeSub": "Removes invalid users from sprint notifications",
     "help:sprintFooter": " `sprint cancel` can only be run by the person who started the sprint or someone with the MANAGE_MESSAGES permission.",
     "help:sprintJoinEdit": "Joins the current sprint but as a user who will not submit a word count. For example, if you are editing, rather than writing.",
     "help:sprintJoinSame": "Joins the current sprint using the project and final word count from your most recent sprint, as your project and starting word count for this one.",


### PR DESCRIPTION
There are always a lot of questions about this in the channel, so I figured it was worth adding to the sprint help command