### PR TITLE
Update error messages to suggest "sprint for" instead of "sprint start"

### DIFF
--- a/data/lang/en.json
+++ b/data/lang/en.json
@@ -468,7 +468,7 @@
     "sprint:purged:none": "No users to purge from sprint notifications",
 
     "sprint:err:alreadyexists": "There is already a sprint running on this server. Please wait until it has finished before creating a new one.",
-    "sprint:err:noexists": "There is no active sprint on this server. Maybe you should start one? `sprint start`",
+    "sprint:err:noexists": "There is no active sprint on this server. Maybe you should start one? `sprint for`",
     "sprint:err:cannotcancel": "Only the sprint creator or the server moderators can cancel this sprint",
     "sprint:err:cannotend": "Only the sprint creator or the server moderators can end this sprint",
     "sprint:err:purgeperms": "Only moderators can purge users from sprint notifications!",

--- a/data/lang/fr.json
+++ b/data/lang/fr.json
@@ -442,7 +442,7 @@
 
     "sprint:err:cmd": "commande de sprint non valide… Lancez `!help sprint` pour plus d’informations sur la commande sprint.",
     "sprint:err:alreadyexists": "il y a déjà un sprint en cours sur ce serveur ! Veuillez attendre la fin du sprint actuel avant de créer un nouveau.",
-    "sprint:err:noexists": "il n’y a pas de sprint en cours sur ce serveur. Peut-être voulez-vous en créer un ? `!sprint start`.",
+    "sprint:err:noexists": "il n’y a pas de sprint en cours sur ce serveur. Peut-être voulez-vous en créer un ? `/sprint for`.",
     "sprint:err:cannotcancel": "seulement le·a créateur·ice du sprint ou un·e modérateur·ice du serveur peut annuler ce sprint.",
     "sprint:err:cannotend": "seulement le·a créateur·ice du sprint ou un·e modérateur·ice du serveur peut conclure ce sprint.",
     "sprint:err:unknown": "",


### PR DESCRIPTION
This is more of a sketch than a prod-quality PR (notably I haven't tried to run the project). Feel free to ignore/close if it's easier to replicate it by hand.